### PR TITLE
[trace] Fatal on disconnect

### DIFF
--- a/udpfwd.go
+++ b/udpfwd.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -83,6 +84,9 @@ func main() {
 		atomic.AddInt64(&inbytes, int64(nin))
 		nout, err := outconn.Write(buf[:nin])
 		if err != nil {
+			if strings.Contains(err.Error(), "transport endpoint is not connected") {
+				log.Fatal(err)
+			}
 			atomic.AddInt64(&outerrors, 1)
 			log.Printf("Error writing %d bytes: %v", nout, err)
 		}


### PR DESCRIPTION
udpfwd can block on an infinite error loop with:
```
2020/11/30 17:19:16 Error writing 0 bytes: write unixgram @->/var/run/datadog-agent/statsd.sock: write: transport endpoint is not connected
2020/11/30 17:19:16 Error writing 0 bytes: write unixgram @->/var/run/datadog-agent/statsd.sock: write: transport endpoint is not connected
```

fatal when it reaches that loop to recover metrics