### PR TITLE
Revert "[trace] Fatal on disconnect"

### DIFF
--- a/udpfwd.go
+++ b/udpfwd.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net"
 	"os"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -84,9 +83,6 @@ func main() {
 		atomic.AddInt64(&inbytes, int64(nin))
 		nout, err := outconn.Write(buf[:nin])
 		if err != nil {
-			if strings.Contains(err.Error(), "transport endpoint is not connected") {
-				log.Fatal(err)
-			}
 			atomic.AddInt64(&outerrors, 1)
 			log.Printf("Error writing %d bytes: %v", nout, err)
 		}


### PR DESCRIPTION
Program fails to run on the rel-env with the fatal
Reverts DataDog/udpfwd#2